### PR TITLE
refresh-bits: don't specify ssh user

### DIFF
--- a/refresh-bits
+++ b/refresh-bits
@@ -12,8 +12,7 @@ devtools_host=
 
 #: SSH options to use.
 #: Those option are optimized for non-interactive key authentication.
-devtools_ssh_opts="-o User=ubuntu"
-devtools_ssh_opts="$devtools_ssh_opts -o BatchMode=yes"
+devtools_ssh_opts="-o BatchMode=yes"
 devtools_ssh_opts="$devtools_ssh_opts -o UserKnownHostsFile=/dev/null"
 devtools_ssh_opts="$devtools_ssh_opts -o CheckHostIP=no"
 devtools_ssh_opts="$devtools_ssh_opts -o StrictHostKeyChecking=no"


### PR DESCRIPTION
Recent snappy images are set up with console-conf and no longer include an `ubuntu` system user. This makes refresh-bits fail when using a remote host even if an ssh config stanza is set up already for that host, so don't specify the user anymore.
